### PR TITLE
feat: add dining table and table check entities

### DIFF
--- a/one-core/src/main/java/com/one/core/domain/model/enums/dining/DiningTableStatus.java
+++ b/one-core/src/main/java/com/one/core/domain/model/enums/dining/DiningTableStatus.java
@@ -1,0 +1,8 @@
+package com.one.core.domain.model.enums.dining;
+
+public enum DiningTableStatus {
+    AVAILABLE,
+    OCCUPIED,
+    RESERVED,
+    OUT_OF_SERVICE
+}

--- a/one-core/src/main/java/com/one/core/domain/model/tenant/table/DiningTable.java
+++ b/one-core/src/main/java/com/one/core/domain/model/tenant/table/DiningTable.java
@@ -1,0 +1,57 @@
+package com.one.core.domain.model.tenant.table;
+
+import com.one.core.domain.model.enums.dining.DiningTableStatus;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "dining_tables")
+@Data
+@EqualsAndHashCode(exclude = {"tableChecks"})
+@ToString(exclude = {"tableChecks"})
+@EntityListeners(AuditingEntityListener.class)
+public class DiningTable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "table_number", nullable = false, unique = true)
+    private Integer tableNumber;
+
+    @Column(nullable = false)
+    private Integer capacity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private DiningTableStatus status;
+
+    @OneToMany(mappedBy = "diningTable", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<TableCheck> tableChecks = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
+        if (status == null) status = DiningTableStatus.AVAILABLE;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+}

--- a/one-core/src/main/java/com/one/core/domain/model/tenant/table/Payment.java
+++ b/one-core/src/main/java/com/one/core/domain/model/tenant/table/Payment.java
@@ -1,0 +1,56 @@
+package com.one.core.domain.model.tenant.table;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+@Entity
+@Table(name = "payments")
+@Data
+@EqualsAndHashCode(exclude = {"tableCheck"})
+@ToString(exclude = {"tableCheck"})
+@EntityListeners(AuditingEntityListener.class)
+public class Payment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "table_check_id", nullable = false)
+    private TableCheck tableCheck;
+
+    @Column(name = "payment_method", nullable = false, length = 50)
+    private String paymentMethod;
+
+    @Column(nullable = false, precision = 14, scale = 2)
+    private BigDecimal amount;
+
+    @Column(name = "paid_at", nullable = false)
+    private OffsetDateTime paidAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        createdAt = now;
+        updatedAt = now;
+        if (paidAt == null) paidAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+}

--- a/one-core/src/main/java/com/one/core/domain/model/tenant/table/TableCheck.java
+++ b/one-core/src/main/java/com/one/core/domain/model/tenant/table/TableCheck.java
@@ -1,0 +1,77 @@
+package com.one.core.domain.model.tenant.table;
+
+import com.one.core.domain.model.tenant.customer.Customer;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "table_checks")
+@Data
+@EqualsAndHashCode(exclude = {"diningTable", "customer", "items", "payments"})
+@ToString(exclude = {"diningTable", "customer", "items", "payments"})
+@EntityListeners(AuditingEntityListener.class)
+public class TableCheck {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "dining_table_id", nullable = false)
+    private DiningTable diningTable;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customer_id")
+    private Customer customer;
+
+    @OneToMany(mappedBy = "tableCheck", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<TableCheckItem> items = new ArrayList<>();
+
+    @OneToMany(mappedBy = "tableCheck", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Payment> payments = new ArrayList<>();
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+
+    public void addItem(TableCheckItem item) {
+        items.add(item);
+        item.setTableCheck(this);
+    }
+
+    public void removeItem(TableCheckItem item) {
+        items.remove(item);
+        item.setTableCheck(null);
+    }
+
+    public void addPayment(Payment payment) {
+        payments.add(payment);
+        payment.setTableCheck(this);
+    }
+
+    public void removePayment(Payment payment) {
+        payments.remove(payment);
+        payment.setTableCheck(null);
+    }
+}

--- a/one-core/src/main/java/com/one/core/domain/model/tenant/table/TableCheckItem.java
+++ b/one-core/src/main/java/com/one/core/domain/model/tenant/table/TableCheckItem.java
@@ -1,0 +1,51 @@
+package com.one.core.domain.model.tenant.table;
+
+import com.one.core.domain.model.tenant.product.Product;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "table_check_items")
+@Data
+@EqualsAndHashCode(exclude = {"tableCheck", "product"})
+@ToString(exclude = {"tableCheck", "product"})
+public class TableCheckItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "table_check_id", nullable = false)
+    private TableCheck tableCheck;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Column(nullable = false, precision = 10, scale = 3)
+    private BigDecimal quantity;
+
+    @Column(name = "unit_price_at_sale", nullable = false, precision = 12, scale = 2)
+    private BigDecimal unitPriceAtSale;
+
+    @Column(name = "discount_per_item", precision = 12, scale = 2)
+    @ColumnDefault("0.00")
+    private BigDecimal discountPerItem = BigDecimal.ZERO;
+
+    @Transient
+    private BigDecimal subtotal;
+
+    public BigDecimal getSubtotal() {
+        if (quantity != null && unitPriceAtSale != null) {
+            BigDecimal discount = (discountPerItem != null) ? discountPerItem : BigDecimal.ZERO;
+            return quantity.multiply(unitPriceAtSale.subtract(discount));
+        }
+        return BigDecimal.ZERO;
+    }
+}


### PR DESCRIPTION
## Summary
- add DiningTable entity with status tracking
- introduce TableCheck, TableCheckItem, and Payment models
- define DiningTableStatus enum

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ebb9f328832bba4eeb53df26b2b6