### PR TITLE
Normalize unit conversions and clarify API units

### DIFF
--- a/one-core/src/main/java/com/one/core/application/controller/tenant/products/ProductController.java
+++ b/one-core/src/main/java/com/one/core/application/controller/tenant/products/ProductController.java
@@ -16,12 +16,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/products")
 @PreAuthorize("hasRole('TENANT_USER') or hasRole('SUPER_ADMIN') or hasRole('TENANT_ADMIN')")
+@Tag(name = "Products", description = "Manage products. Quantities are stored in base units (grams, milliliters, units) and normalized automatically.")
 public class ProductController {
 
     private final ProductService productService;
@@ -51,12 +54,14 @@ public class ProductController {
         return ResponseEntity.ok(productService.getProductBySku(sku));
     }
 
+    @Operation(summary = "Create product", description = "Quantities are stored in base units (grams, milliliters, units) and normalized automatically.")
     @PostMapping
     public ResponseEntity<ProductDTO> createProduct(@Valid @RequestBody ProductDTO productDTO) {
         ProductDTO createdProduct = productService.createProduct(productDTO);
         return new ResponseEntity<>(createdProduct, HttpStatus.CREATED);
     }
 
+    @Operation(summary = "Update product", description = "Quantities are stored in base units (grams, milliliters, units) and normalized automatically.")
     @PutMapping("/{id}")
     public ResponseEntity<ProductDTO> updateProduct(@PathVariable Long id, @Valid @RequestBody ProductDTO productDTO) {
         return ResponseEntity.ok(productService.updateProduct(id, productDTO));

--- a/one-core/src/main/java/com/one/core/application/dto/tenant/product/ProductDTO.java
+++ b/one-core/src/main/java/com/one/core/application/dto/tenant/product/ProductDTO.java
@@ -4,6 +4,7 @@ import com.one.core.domain.model.enums.ProductType;
 import com.one.core.domain.model.enums.UnitOfMeasure;
 import lombok.Data;
 import java.math.BigDecimal;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Data
 public class ProductDTO {
@@ -19,8 +20,14 @@ public class ProductDTO {
     private String defaultSupplierName;
     private BigDecimal purchasePrice;
     private BigDecimal salePrice;
+
+    @Schema(description = "Unit of measure for stock quantities. All amounts are stored in base units (grams, milliliters or units) and normalized automatically.")
     private UnitOfMeasure unitOfMeasure;
+
+    @Schema(description = "Current stock expressed in unitOfMeasure. Values are normalized to base units.")
     private BigDecimal currentStock;
+
+    @Schema(description = "Minimum stock level expressed in unitOfMeasure. Values are normalized to base units.")
     private BigDecimal minimumStockLevel;
     private boolean isActive;
     private String barcode;

--- a/one-core/src/main/java/com/one/core/application/mapper/product/ProductMapper.java
+++ b/one-core/src/main/java/com/one/core/application/mapper/product/ProductMapper.java
@@ -46,9 +46,12 @@ public class ProductMapper {
 
         dto.setPurchasePrice(product.getPurchasePrice());
         dto.setSalePrice(product.getSalePrice());
-        dto.setUnitOfMeasure(product.getUnitOfMeasure());
-        dto.setCurrentStock(unitConversionService.fromBaseUnit(product.getCurrentStock(), product.getUnitOfMeasure()));
-        dto.setMinimumStockLevel(unitConversionService.fromBaseUnit(product.getMinimumStockLevel(), product.getUnitOfMeasure()));
+
+        UnitConversionService.NormalizedQuantity normalizedStock =
+                unitConversionService.normalizeFromBaseUnit(product.getCurrentStock(), product.getUnitOfMeasure());
+        dto.setUnitOfMeasure(normalizedStock.unit());
+        dto.setCurrentStock(normalizedStock.quantity());
+        dto.setMinimumStockLevel(unitConversionService.fromBaseUnit(product.getMinimumStockLevel(), normalizedStock.unit()));
         dto.setActive(product.isActive());
         dto.setBarcode(product.getBarcode());
         dto.setImageUrl(product.getImageUrl());

--- a/one-core/src/main/java/com/one/core/domain/service/common/UnitConversionService.java
+++ b/one-core/src/main/java/com/one/core/domain/service/common/UnitConversionService.java
@@ -43,4 +43,43 @@ public class UnitConversionService {
         }
         return unit.fromBase(quantity);
     }
+
+    /**
+     * Normalizes a quantity expressed in base units selecting the most
+     * appropriate unit of measure. If the quantity is less than one in the
+     * requested unit, it will be converted to the next smaller unit (e.g. 0.5
+     * KG becomes 500 G).
+     *
+     * @param baseQuantity quantity expressed in base units
+     * @param preferredUnit unit of measure requested by the caller
+     * @return normalized quantity and unit
+     */
+    public NormalizedQuantity normalizeFromBaseUnit(BigDecimal baseQuantity, UnitOfMeasure preferredUnit) {
+        if (baseQuantity == null || preferredUnit == null) {
+            return new NormalizedQuantity(baseQuantity, preferredUnit);
+        }
+
+        BigDecimal converted = fromBaseUnit(baseQuantity, preferredUnit);
+        if (converted.compareTo(BigDecimal.ONE) < 0) {
+            UnitOfMeasure smaller = smallerUnit(preferredUnit);
+            if (smaller != null) {
+                return new NormalizedQuantity(fromBaseUnit(baseQuantity, smaller), smaller);
+            }
+        }
+        return new NormalizedQuantity(converted, preferredUnit);
+    }
+
+    private UnitOfMeasure smallerUnit(UnitOfMeasure unit) {
+        return switch (unit) {
+            case KG -> UnitOfMeasure.G;
+            case L -> UnitOfMeasure.ML;
+            default -> null;
+        };
+    }
+
+    /**
+     * Simple container for a normalized quantity and its unit of measure.
+     * Records are used here for brevity and immutability.
+     */
+    public record NormalizedQuantity(BigDecimal quantity, UnitOfMeasure unit) { }
 }

--- a/one-core/src/test/java/com/one/core/domain/service/common/UnitConversionServiceTest.java
+++ b/one-core/src/test/java/com/one/core/domain/service/common/UnitConversionServiceTest.java
@@ -1,0 +1,49 @@
+package com.one.core.domain.service.common;
+
+import com.one.core.domain.model.enums.UnitOfMeasure;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UnitConversionServiceTest {
+
+    private final UnitConversionService service = new UnitConversionService();
+
+    @Test
+    void toBaseUnitConvertsKilogramsToGrams() {
+        BigDecimal result = service.toBaseUnit(new BigDecimal("0.5"), UnitOfMeasure.KG);
+        assertEquals(new BigDecimal("500"), result);
+    }
+
+    @Test
+    void fromBaseUnitConvertsGramsToKilograms() {
+        BigDecimal result = service.fromBaseUnit(new BigDecimal("1500"), UnitOfMeasure.KG);
+        assertEquals(new BigDecimal("1.5"), result);
+    }
+
+    @Test
+    void normalizeFromBaseUnitUsesSmallerUnitWhenLessThanOne() {
+        UnitConversionService.NormalizedQuantity normalized =
+                service.normalizeFromBaseUnit(new BigDecimal("500"), UnitOfMeasure.KG);
+        assertEquals(new BigDecimal("500"), normalized.quantity());
+        assertEquals(UnitOfMeasure.G, normalized.unit());
+    }
+
+    @Test
+    void normalizeFromBaseUnitKeepsUnitWhenGreaterOrEqualToOne() {
+        UnitConversionService.NormalizedQuantity normalized =
+                service.normalizeFromBaseUnit(new BigDecimal("2000"), UnitOfMeasure.KG);
+        assertEquals(new BigDecimal("2"), normalized.quantity());
+        assertEquals(UnitOfMeasure.KG, normalized.unit());
+    }
+
+    @Test
+    void normalizeFromBaseUnitHandlesVolume() {
+        UnitConversionService.NormalizedQuantity normalized =
+                service.normalizeFromBaseUnit(new BigDecimal("500"), UnitOfMeasure.L);
+        assertEquals(new BigDecimal("500"), normalized.quantity());
+        assertEquals(UnitOfMeasure.ML, normalized.unit());
+    }
+}


### PR DESCRIPTION
## Summary
- Add normalization logic to UnitConversionService to switch to smaller unit when amount is <1 in requested unit
- Adjust ProductMapper and API documentation to explain automatic normalization and base units
- Cover conversion and normalization with unit tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.0)*

------
https://chatgpt.com/codex/tasks/task_e_68acf14701b8832ba2947d7d31533524